### PR TITLE
Milestone 4: Build Region Filter Logic

### DIFF
--- a/app/Compounds/ControlsCompound.js
+++ b/app/Compounds/ControlsCompound.js
@@ -103,6 +103,17 @@ function ControlsCompound({ children }) {
     setRegionFilterTerm("africa")
   }
 
+  function doEuropeCheckBoxActions() {
+    setAllRegionsChecked(false)
+    setIsAsiaRegionChecked(false)
+    setIsAfricaRegionChecked(false)
+    setIsEuropeRegionChecked(true)
+    setIsAmericasRegionChecked(false)
+    setIsOceaniaRegionChecked(false)
+    setIsPolarRegionChecked(false)
+    setRegionFilterTerm("europe")
+  }
+
   return (
     <>
       <ControlsSectionWrapper>
@@ -163,7 +174,12 @@ function ControlsCompound({ children }) {
                   checked={isAfricaRegionChecked}
                   onClick={() => doAfricaCheckBoxActions()}
                 />
-                <CheckBox id="europe" label="Europe"></CheckBox>
+                <CheckBox
+                  id="europe"
+                  label="Europe"
+                  checked={isEuropeRegionChecked}
+                  onClick={() => doEuropeCheckBoxActions()}
+                />
               </Box>
               <Box>
                 <CheckBox id="americas" label="Americas"></CheckBox>

--- a/app/Compounds/ControlsCompound.js
+++ b/app/Compounds/ControlsCompound.js
@@ -70,6 +70,17 @@ function ControlsCompound({ children }) {
     setSearchTerm(event.target.value)
   }
 
+  function doAllRegionsCheckBoxActions() {
+    setAllRegionsChecked(true)
+    setIsAsiaRegionChecked(false)
+    setIsAfricaRegionChecked(false)
+    setIsEuropeRegionChecked(false)
+    setIsAmericasRegionChecked(false)
+    setIsOceaniaRegionChecked(false)
+    setIsPolarRegionChecked(false)
+    setRegionFilterTerm("all")
+  }
+
   return (
     <>
       <ControlsSectionWrapper>
@@ -110,7 +121,12 @@ function ControlsCompound({ children }) {
             <RegionFilterWrapper>
               <Text>Region Filter</Text>
               <Box>
-                <CheckBox id="all" label="All Regions"></CheckBox>
+                <CheckBox
+                  id="all"
+                  label="All Regions"
+                  checked={isAllRegionsChecked}
+                  onClick={() => doAllRegionsCheckBoxActions()}
+                />
               </Box>
               <Box>
                 <CheckBox id="asia" label="Asia"></CheckBox>

--- a/app/Compounds/ControlsCompound.js
+++ b/app/Compounds/ControlsCompound.js
@@ -124,6 +124,17 @@ function ControlsCompound({ children }) {
     setIsPolarRegionChecked(false)
     setRegionFilterTerm("americas")
   }
+
+  function doOceaniaCheckBoxActions() {
+    setAllRegionsChecked(false)
+    setIsAsiaRegionChecked(false)
+    setIsAfricaRegionChecked(false)
+    setIsEuropeRegionChecked(false)
+    setIsAmericasRegionChecked(false)
+    setIsOceaniaRegionChecked(true)
+    setIsPolarRegionChecked(false)
+    setRegionFilterTerm("oceania")
+  }
   
   return (
     <>
@@ -199,7 +210,12 @@ function ControlsCompound({ children }) {
                   checked={isAmericasRegionChecked}
                   onClick={() => doAmericasCheckBoxActions()}
                 />
-                <CheckBox id="oceania" label="Oceania"></CheckBox>
+                <CheckBox
+                  id="oceania"
+                  label="Oceania"
+                  checked={isOceaniaRegionChecked}
+                  onClick={() => doOceaniaCheckBoxActions()}
+                />
                 <CheckBox id="polar" label="Polar"></CheckBox>
               </Box>
             </RegionFilterWrapper>

--- a/app/Compounds/ControlsCompound.js
+++ b/app/Compounds/ControlsCompound.js
@@ -37,6 +37,13 @@ function ControlsCompound({ children }) {
     false
   )
   const [isLangCheckBoxChecked, setIsLangCheckBoxChecked] = useState(false)
+  const [isAllRegionsChecked, setAllRegionsChecked] = useState(true)
+  const [isAsiaRegionChecked, setIsAsiaRegionChecked] = useState(false)
+  const [isAfricaRegionChecked, setIsAfricaRegionChecked] = useState(false)
+  const [isEuropeRegionChecked, setIsEuropeRegionChecked] = useState(false)
+  const [isAmericasRegionChecked, setIsAmericasRegionChecked] = useState(false)
+  const [isOceaniaRegionChecked, setIsOceaniaRegionChecked] = useState(false)
+  const [isPolarRegionChecked, setIsPolarRegionChecked] = useState(false)
 
   function doNameCheckBoxActions() {
     setIsNameCheckBoxChecked(true)

--- a/app/Compounds/ControlsCompound.js
+++ b/app/Compounds/ControlsCompound.js
@@ -92,6 +92,17 @@ function ControlsCompound({ children }) {
     setRegionFilterTerm("asia")
   }
 
+  function doAfricaCheckBoxActions() {
+    setAllRegionsChecked(false)
+    setIsAsiaRegionChecked(false)
+    setIsAfricaRegionChecked(true)
+    setIsEuropeRegionChecked(false)
+    setIsAmericasRegionChecked(false)
+    setIsOceaniaRegionChecked(false)
+    setIsPolarRegionChecked(false)
+    setRegionFilterTerm("africa")
+  }
+
   return (
     <>
       <ControlsSectionWrapper>
@@ -146,7 +157,12 @@ function ControlsCompound({ children }) {
                   checked={isAsiaRegionChecked}
                   onClick={() => doAsiaCheckBoxActions()}
                 />
-                <CheckBox id="africa" label="Africa"></CheckBox>
+                <CheckBox
+                  id="africa"
+                  label="Africa"
+                  checked={isAfricaRegionChecked}
+                  onClick={() => doAfricaCheckBoxActions()}
+                />
                 <CheckBox id="europe" label="Europe"></CheckBox>
               </Box>
               <Box>

--- a/app/Compounds/ControlsCompound.js
+++ b/app/Compounds/ControlsCompound.js
@@ -114,6 +114,17 @@ function ControlsCompound({ children }) {
     setRegionFilterTerm("europe")
   }
 
+  function doAmericasCheckBoxActions() {
+    setAllRegionsChecked(false)
+    setIsAsiaRegionChecked(false)
+    setIsAfricaRegionChecked(false)
+    setIsEuropeRegionChecked(false)
+    setIsAmericasRegionChecked(true)
+    setIsOceaniaRegionChecked(false)
+    setIsPolarRegionChecked(false)
+    setRegionFilterTerm("americas")
+  }
+  
   return (
     <>
       <ControlsSectionWrapper>
@@ -182,7 +193,12 @@ function ControlsCompound({ children }) {
                 />
               </Box>
               <Box>
-                <CheckBox id="americas" label="Americas"></CheckBox>
+                <CheckBox
+                  id="americas"
+                  label="Americas"
+                  checked={isAmericasRegionChecked}
+                  onClick={() => doAmericasCheckBoxActions()}
+                />
                 <CheckBox id="oceania" label="Oceania"></CheckBox>
                 <CheckBox id="polar" label="Polar"></CheckBox>
               </Box>

--- a/app/Compounds/ControlsCompound.js
+++ b/app/Compounds/ControlsCompound.js
@@ -81,6 +81,17 @@ function ControlsCompound({ children }) {
     setRegionFilterTerm("all")
   }
 
+  function doAsiaCheckBoxActions() {
+    setAllRegionsChecked(false)
+    setIsAsiaRegionChecked(true)
+    setIsAfricaRegionChecked(false)
+    setIsEuropeRegionChecked(false)
+    setIsAmericasRegionChecked(false)
+    setIsOceaniaRegionChecked(false)
+    setIsPolarRegionChecked(false)
+    setRegionFilterTerm("asia")
+  }
+
   return (
     <>
       <ControlsSectionWrapper>
@@ -129,7 +140,12 @@ function ControlsCompound({ children }) {
                 />
               </Box>
               <Box>
-                <CheckBox id="asia" label="Asia"></CheckBox>
+                <CheckBox
+                  id="asia"
+                  label="Asia"
+                  checked={isAsiaRegionChecked}
+                  onClick={() => doAsiaCheckBoxActions()}
+                />
                 <CheckBox id="africa" label="Africa"></CheckBox>
                 <CheckBox id="europe" label="Europe"></CheckBox>
               </Box>

--- a/app/Compounds/ControlsCompound.js
+++ b/app/Compounds/ControlsCompound.js
@@ -135,7 +135,18 @@ function ControlsCompound({ children }) {
     setIsPolarRegionChecked(false)
     setRegionFilterTerm("oceania")
   }
-  
+
+  function doPolarCheckBoxActions() {
+    setAllRegionsChecked(false)
+    setIsAsiaRegionChecked(false)
+    setIsAfricaRegionChecked(false)
+    setIsEuropeRegionChecked(false)
+    setIsAmericasRegionChecked(false)
+    setIsOceaniaRegionChecked(false)
+    setIsPolarRegionChecked(true)
+    setRegionFilterTerm("polar")
+  }
+
   return (
     <>
       <ControlsSectionWrapper>
@@ -216,7 +227,12 @@ function ControlsCompound({ children }) {
                   checked={isOceaniaRegionChecked}
                   onClick={() => doOceaniaCheckBoxActions()}
                 />
-                <CheckBox id="polar" label="Polar"></CheckBox>
+                <CheckBox
+                  id="polar"
+                  label="Polar"
+                  checked={isPolarRegionChecked}
+                  onClick={() => doPolarCheckBoxActions()}
+                />
               </Box>
             </RegionFilterWrapper>
           </Grid>

--- a/app/Compounds/ControlsCompound.js
+++ b/app/Compounds/ControlsCompound.js
@@ -19,6 +19,7 @@ import ClearButtonWrapper from "../Components/Controls/ClearButtonWrapper"
 import ClearButton from "../Components/Controls/ClearButton"
 import { SearchTermContext } from "../Context/SearchTermContext"
 import { CheckBoxFilterTermContext } from "../Context/CheckBoxFilterTermContext"
+import { RegionFilterTermContext } from "../Context/RegionFilterTermContext"
 
 export default ControlsCompound
 
@@ -26,6 +27,9 @@ function ControlsCompound({ children }) {
   const [searchTerm, setSearchTerm] = useContext(SearchTermContext)
   const [checkBoxFilterTerm, setCheckBoxFilterTerm] = useContext(
     CheckBoxFilterTermContext
+  )
+  const [regionFilterTerm, setRegionFilterTerm] = useContext(
+    RegionFilterTermContext
   )
 
   const [isNameCheckBoxChecked, setIsNameCheckBoxChecked] = useState(true)

--- a/app/Compounds/DashboardCompound.js
+++ b/app/Compounds/DashboardCompound.js
@@ -3,12 +3,14 @@ import DisplayCompound from "./DisplayCompound"
 import ControlsCompound from "./ControlsCompound"
 import { SearchTermContext } from "../Context/SearchTermContext"
 import { CheckBoxFilterTermContext } from "../Context/CheckBoxFilterTermContext"
+import { RegionFilterTermContext } from "../Context/RegionFilterTermContext"
 
 export default DashboardCompound
 
 function DashboardCompound({ children }) {
   const [searchTerm, setSearchTerm] = useState("")
   const [checkBoxFilterTerm, setCheckBoxFilterTerm] = useState("name")
+  const [regionFilterTerm, setRegionFilterTerm] = useState("all")
 
   return (
     <>
@@ -16,9 +18,13 @@ function DashboardCompound({ children }) {
         <CheckBoxFilterTermContext.Provider
           value={[checkBoxFilterTerm, setCheckBoxFilterTerm]}
         >
-          <ControlsCompound />
-          <DisplayCompound />
-          {children}
+          <RegionFilterTermContext.Provider
+            value={[regionFilterTerm, setRegionFilterTerm]}
+          >
+            <ControlsCompound />
+            <DisplayCompound />
+            {children}
+          </RegionFilterTermContext.Provider>
         </CheckBoxFilterTermContext.Provider>
       </SearchTermContext.Provider>
     </>

--- a/app/Compounds/DisplayCompound.js
+++ b/app/Compounds/DisplayCompound.js
@@ -11,6 +11,7 @@ import TableRow from "@material-ui/core/TableRow"
 import Paper from "@material-ui/core/Paper"
 import { SearchTermContext } from "../Context/SearchTermContext"
 import { CheckBoxFilterTermContext } from "../Context/CheckBoxFilterTermContext"
+import { RegionFilterTermContext } from "../Context/RegionFilterTermContext"
 
 export default DisplayCompound
 
@@ -28,6 +29,9 @@ function DisplayCompound({ children }) {
   const [searchTerm, setSearchTerm] = useContext(SearchTermContext)
   const [checkBoxFilterTerm, setCheckBoxFilterTerm] = useContext(
     CheckBoxFilterTermContext
+  )
+  const [regionFilterTerm, setRegionFilterTerm] = useContext(
+    RegionFilterTermContext
   )
 
   return (

--- a/app/Compounds/DisplayCompound.js
+++ b/app/Compounds/DisplayCompound.js
@@ -50,7 +50,63 @@ function DisplayCompound({ children }) {
               </TableRow>
             </TableHead>
             <TableBody>
-              {searchTerm !== "" && checkBoxFilterTerm === "languages" //case-8
+              {searchTerm !== "" && //case-3
+              checkBoxFilterTerm === "languages" &&
+              regionFilterTerm !== "all"
+                ? data
+                    .filter(
+                      (item) =>
+                        item.languages
+                          .map((lang) => lang.name)
+                          .toString()
+                          .toLowerCase()
+                          .includes(searchTerm.toLowerCase()) &&
+                        item.region.toLowerCase() ===
+                          regionFilterTerm.toLowerCase()
+                    )
+
+                    .map((item, index) => (
+                      <TableRow key={index}>
+                        <TableCell>{item.name}</TableCell>
+                        <TableCell>{item.capital}</TableCell>
+                        <TableCell>{item.region}</TableCell>
+                        <TableCell>{item.population}</TableCell>
+                        <TableCell>
+                          {item.languages.map((lang) => `${lang.name}, `)}
+                        </TableCell>
+                        <TableCell>
+                          {item.timezones.toString().split(",").join(" ")}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                : searchTerm !== "" && //case-4
+                  (checkBoxFilterTerm === "name" ||
+                    checkBoxFilterTerm === "capital") &&
+                  regionFilterTerm !== "all"
+                ? data
+                    .filter(
+                      (item) =>
+                        item[checkBoxFilterTerm]
+                          .toLowerCase()
+                          .includes(searchTerm.toLowerCase()) &&
+                        item.region.toLowerCase() ===
+                          regionFilterTerm.toLowerCase()
+                    )
+                    .map((item, index) => (
+                      <TableRow key={index}>
+                        <TableCell>{item.name}</TableCell>
+                        <TableCell>{item.capital}</TableCell>
+                        <TableCell>{item.region}</TableCell>
+                        <TableCell>{item.population}</TableCell>
+                        <TableCell>
+                          {item.languages.map((lang) => `${lang.name}, `)}
+                        </TableCell>
+                        <TableCell>
+                          {item.timezones.toString().split(",").join(" ")}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                : searchTerm !== "" && checkBoxFilterTerm === "languages" //case-8
                 ? data
                     .filter((item) =>
                       item.languages
@@ -81,6 +137,27 @@ function DisplayCompound({ children }) {
                       item[checkBoxFilterTerm]
                         .toLowerCase()
                         .includes(searchTerm.toLowerCase())
+                    )
+                    .map((item, index) => (
+                      <TableRow key={index}>
+                        <TableCell>{item.name}</TableCell>
+                        <TableCell>{item.capital}</TableCell>
+                        <TableCell>{item.region}</TableCell>
+                        <TableCell>{item.population}</TableCell>
+                        <TableCell>
+                          {item.languages.map((lang) => `${lang.name}, `)}
+                        </TableCell>
+                        <TableCell>
+                          {item.timezones.toString().split(",").join(" ")}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                : regionFilterTerm !== "all" //case-10
+                ? data
+                    .filter(
+                      (item) =>
+                        item.region.toLowerCase() ===
+                        regionFilterTerm.toLowerCase()
                     )
                     .map((item, index) => (
                       <TableRow key={index}>

--- a/app/Context/RegionFilterTermContext.js
+++ b/app/Context/RegionFilterTermContext.js
@@ -1,0 +1,3 @@
+import { createContext } from "react"
+
+export const RegionFilterTermContext = createContext(null)


### PR DESCRIPTION
### Milestone 4: Build Region Filter Logic

This milestone includes:

- Adjust all-regions checkbox" to be checked by default & adjust all other checkboxes in region-filter to NOT be checked by default.

- Build a logic to have only 1 checkbox checked at a time.
Example:
If all-regions checkbox is checked (which is the default option), all other checkboxes will NOT be checked.
If the user checked asia checkbox, the all-regions checkbox will NOT be checked.
If the user then checked africa checkbox,  asia checkbox will NOT be checked.
and the same for all other checkboxes ... 

- Build a logic to display all countries from all regions when all-region checkbox is checked.

- Build a logic to display  all countries which their region matches the checked region checkbox , if the user used only region-filter to filter the countries. 
Example:
if the user used only region-filter and checked africa checkbox, it will display only the countries in africa region.

- Build a logic to combine search-filter & region-filter.
Example:
if the user used search filter and the input in search field  was "united" & checked checkbox in search filter was "name checkbox" & checked checkbox in region-filter was "americas". 
The user will get all countries which their name includes the word "united" and exist in americas region.


